### PR TITLE
Created an MVP contact page to replace more complex form version

### DIFF
--- a/src/Components/ContactSimple/index.js
+++ b/src/Components/ContactSimple/index.js
@@ -1,0 +1,39 @@
+import React from 'react';
+import styled, { withTheme } from "styled-components";
+
+const Wrapper = styled.div`
+margin: 100px 0 200px 0;
+text-align: center;
+`
+
+const ContactLink = styled.a`
+    color: rgb(${props => props.theme.link});
+    background-color: rgb(${props => props.theme.background});
+    font-family: tiemposheadline;
+    transition: 0.3s ease-in-out;
+
+	:hover {
+		color: rgb(${props => props.theme.link});
+		filter: brightness(120%);
+	}
+	
+	:after {
+        color: rgb(${props => props.theme.background});
+        background: rgb(${props => props.theme.link})
+    }
+`
+
+class ContactForm extends React.Component {
+  
+    render() {
+        return (
+            <Wrapper>
+                <p> Drop me an email. Easy.</p>
+                <h3> <ContactLink href="mailto:chris@hastings-spital.co.uk">chris@hastings-spital.co.uk</ContactLink></h3>
+                
+            </Wrapper>
+        );
+    }
+}
+
+export default withTheme(ContactForm);

--- a/src/Components/Footer/index.js
+++ b/src/Components/Footer/index.js
@@ -46,7 +46,7 @@ class Footer extends Component {
         return (
             <Container className="container">
                 <FooterRow>
-                    Made by me, with love ❤️
+                    Made by me.
                 </FooterRow>
                 <FooterRow>
                     <SocialLink href="https://uk.linkedin.com/in/chrismhs" target="blank" className="fancy">LinkedIn</SocialLink>

--- a/src/Pages/Contact/index.js
+++ b/src/Pages/Contact/index.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import styled, { withTheme } from "styled-components";
 
-import ContactForm from '../../Components/ContactForm';
+import ContactSimple from '../../Components/ContactSimple';
 
 const Container = styled.div`
     padding-top: 120px;
@@ -16,9 +16,8 @@ class Contact extends Component {
         return (
             <Container className="page">
             <div className="row">
-                <div className="col-xs-10 col-sm-8 col-md-6 col-xl-4 offset-xs-1 offset-sm-2 offset-md-3 offset-xl-4">
-                    {/* <h3>Contact</h3> */}
-                    <ContactForm/>
+                <div className="col-8 offset-2">
+                    <ContactSimple/>
                 </div>
             </div>
             </Container>


### PR DESCRIPTION
I've swapped to using text explaining how to email me, rather than a form, as:
1. I don't have a back-end service to deal with sending emails on behalf of the user
2. Not everyone has their email client set up to handle `mailto:` URIs, so it's possible a form that auto-created an email wouldn't work for everyone.

Having a page like this, with the email address listed _and_ a link that will work for those that have the `mailto` URIs set up, means we have graceful fallback for all users.