### PR TITLE
Auto-generate anchor tags for headings

### DIFF
--- a/src/Components/AnchorHeader/index.js
+++ b/src/Components/AnchorHeader/index.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import styled, { withTheme } from "styled-components";
+
+const H3 = styled.h3`
+    padding-bottom: 10px;
+`
+
+class AnchorHeader extends React.Component {
+	name() {
+		// NB. If we want to have child elements, this will need to be more complex
+		const text = this.props.children;
+		return text.toLowerCase().replace(/[^a-z0-9]+/g, '-');
+	}
+
+	render() {
+		return (
+			<H3 id={this.name()}>{this.props.children}</H3>
+		);
+	}
+}
+
+export default withTheme(AnchorHeader);

--- a/src/Components/TextSections/TextSection/index.js
+++ b/src/Components/TextSections/TextSection/index.js
@@ -1,12 +1,9 @@
 import React, { Component } from 'react';
 import styled, { withTheme } from "styled-components";
+import AnchorHeader from '../../AnchorHeader';
 
 const Container = styled.div`
     padding: 30px 0 30px 0;
-`
-
-const SectionHeader = styled.h3`
-    padding-bottom: 10px;
 `
 
 class TextSection extends Component {
@@ -15,7 +12,7 @@ class TextSection extends Component {
             <Container className="container">
                 <div className="row">
                     <div className="col-sm-10 col-lg-8 col-xl-6 offset-sm-1 offset-lg-2 offset-xl-3">
-                        <SectionHeader>{this.props.sectionHeader}</SectionHeader>
+                        <AnchorHeader>{this.props.sectionHeader}</AnchorHeader>
                         {this.props.sectionParagraph.map((paragraph,i) => {
                             return(
                                 <p key={i}>{paragraph}</p>


### PR DESCRIPTION
New `AnchorHeading` component which auto-generates valid IDs for h3 tags such that we (one day) will be able to link to them with the hash part of the window location.

Cannot be used yet, because React Router is being used with hash location, so this is kinda broken!

I'll take a look at this when I get some time!